### PR TITLE
run dos2unix on both dockerfiles to ensure it works on windows

### DIFF
--- a/backend/post-service/Dockerfile
+++ b/backend/post-service/Dockerfile
@@ -5,6 +5,7 @@ WORKDIR app
 COPY mvnw .
 COPY .mvn .mvn
 COPY pom.xml .
+RUN dos2unix mvnw
 RUN ./mvnw dependency:go-offline
 
 COPY src src

--- a/backend/user-service/Dockerfile
+++ b/backend/user-service/Dockerfile
@@ -5,6 +5,7 @@ WORKDIR app
 COPY mvnw .
 COPY .mvn .mvn
 COPY pom.xml .
+RUN dos2unix mvnw
 RUN ./mvnw dependency:go-offline
 
 COPY src src


### PR DESCRIPTION
Fixed a problem while pulling the repo from git, I was required to run dos2unix on both mvnw files to run docker. 