### PR TITLE
Spa 227 zaimplementowanie endpointu api posts comments

### DIFF
--- a/backend/gateway-service/src/main/java/com/speakapp/apigateway/ApiGatewayApplication.java
+++ b/backend/gateway-service/src/main/java/com/speakapp/apigateway/ApiGatewayApplication.java
@@ -15,7 +15,7 @@ public class ApiGatewayApplication {
     public RouteLocator customRouteLocator(RouteLocatorBuilder builder) {
         return builder.routes()
                 .route("post-service", r -> r
-                        .path("/api/posts/**")
+                        .path("/api/posts/**", "/api/comments/**")
                         .uri("http://post-service:8082")
                 )
                 .route("user-service", r -> r

--- a/backend/post-service/src/main/java/com/speakapp/postservice/controllers/CommentController.java
+++ b/backend/post-service/src/main/java/com/speakapp/postservice/controllers/CommentController.java
@@ -1,0 +1,26 @@
+package com.speakapp.postservice.controllers;
+
+import com.speakapp.postservice.dtos.CommentPageGetDTO;
+import com.speakapp.postservice.services.CommentService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/api/posts")
+@RequiredArgsConstructor
+public class CommentController {
+
+    private final CommentService commentService;
+
+    @GetMapping("/comments/")
+    @ResponseStatus(HttpStatus.OK)
+    public CommentPageGetDTO getCommentsForPost(@RequestParam(defaultValue = "0") int pageNumber,
+                                                @RequestParam(defaultValue = "10") int pageSize,
+                                                @RequestParam UUID postId,
+                                                @RequestHeader("UserId") UUID userId ){
+        return commentService.getCommentsForPost(pageNumber, pageSize, postId, userId);
+    }
+}

--- a/backend/post-service/src/main/java/com/speakapp/postservice/controllers/CommentController.java
+++ b/backend/post-service/src/main/java/com/speakapp/postservice/controllers/CommentController.java
@@ -9,13 +9,13 @@ import org.springframework.web.bind.annotation.*;
 import java.util.UUID;
 
 @RestController
-@RequestMapping("/api/posts")
+@RequestMapping("/api/comments")
 @RequiredArgsConstructor
 public class CommentController {
 
     private final CommentService commentService;
 
-    @GetMapping("/comments/")
+    @GetMapping("")
     @ResponseStatus(HttpStatus.OK)
     public CommentPageGetDTO getCommentsForPost(@RequestParam(defaultValue = "0") int pageNumber,
                                                 @RequestParam(defaultValue = "10") int pageSize,

--- a/backend/post-service/src/main/java/com/speakapp/postservice/controllers/PostController.java
+++ b/backend/post-service/src/main/java/com/speakapp/postservice/controllers/PostController.java
@@ -60,13 +60,4 @@ public class PostController {
         @RequestParam(defaultValue = "5") int pageSize,  @RequestHeader("UserId") UUID userId ){
       return postService.getLatestPosts(pageNumber, pageSize, userId);
     }
-
-    @GetMapping("/comments/")
-    @ResponseStatus(HttpStatus.OK)
-    public CommentPageGetDTO getCommentsForPost(@RequestParam(defaultValue = "0") int pageNumber,
-                                                @RequestParam(defaultValue = "10") int pageSize,
-                                                @RequestParam UUID postId,
-                                                @RequestHeader("UserId") UUID userId ){
-        return postService.getCommentsForPost(pageNumber, pageSize, postId, userId);
-    }
 }

--- a/backend/post-service/src/main/java/com/speakapp/postservice/controllers/PostController.java
+++ b/backend/post-service/src/main/java/com/speakapp/postservice/controllers/PostController.java
@@ -1,6 +1,5 @@
 package com.speakapp.postservice.controllers;
 
-import com.speakapp.postservice.dtos.CommentPageGetDTO;
 import com.speakapp.postservice.dtos.PostCreateDTO;
 import com.speakapp.postservice.dtos.PostGetDTO;
 import com.speakapp.postservice.dtos.ReactionsGetDTO;

--- a/backend/post-service/src/main/java/com/speakapp/postservice/dtos/CommentGetDTO.java
+++ b/backend/post-service/src/main/java/com/speakapp/postservice/dtos/CommentGetDTO.java
@@ -5,6 +5,7 @@ import lombok.Builder;
 import lombok.Value;
 import lombok.extern.jackson.Jacksonized;
 
+import java.time.Instant;
 import java.util.UUID;
 
 @Value
@@ -17,6 +18,10 @@ public class CommentGetDTO {
     String content;
 
     UserGetDTO author;
+
+    Instant createdAt;
+
+    Instant modifiedAt;
 
     ReactionsGetDTO reactionsGetDTO;
 

--- a/backend/post-service/src/main/java/com/speakapp/postservice/dtos/CommentPageGetDTO.java
+++ b/backend/post-service/src/main/java/com/speakapp/postservice/dtos/CommentPageGetDTO.java
@@ -17,4 +17,6 @@ public class CommentPageGetDTO {
     int pageSize;
 
     int totalPages;
+
+    Long totalComments;
 }

--- a/backend/post-service/src/main/java/com/speakapp/postservice/mappers/CommentPageMapper.java
+++ b/backend/post-service/src/main/java/com/speakapp/postservice/mappers/CommentPageMapper.java
@@ -12,5 +12,8 @@ import java.util.List;
 public interface CommentPageMapper {
     @Mapping(target = "currentPage", source = "pageable.pageNumber")
     @Mapping(target = "pageSize", source = "pageable.pageSize")
-    CommentPageGetDTO toGetDTO(List<CommentGetDTO> commentGetDTOS, Pageable pageable, int totalPages);
+    CommentPageGetDTO toGetDTO(List<CommentGetDTO> commentGetDTOS,
+                               Pageable pageable,
+                               int totalPages,
+                               long totalComments);
 }

--- a/backend/post-service/src/main/java/com/speakapp/postservice/mappers/CommentPageMapper.java
+++ b/backend/post-service/src/main/java/com/speakapp/postservice/mappers/CommentPageMapper.java
@@ -15,5 +15,5 @@ public interface CommentPageMapper {
     CommentPageGetDTO toGetDTO(List<CommentGetDTO> commentGetDTOS,
                                Pageable pageable,
                                int totalPages,
-                               long totalComments);
+                               Long totalComments);
 }

--- a/backend/post-service/src/main/java/com/speakapp/postservice/services/CommentService.java
+++ b/backend/post-service/src/main/java/com/speakapp/postservice/services/CommentService.java
@@ -1,0 +1,120 @@
+package com.speakapp.postservice.services;
+
+import com.speakapp.postservice.communication.UserServiceCommunicationClient;
+import com.speakapp.postservice.dtos.CommentGetDTO;
+import com.speakapp.postservice.dtos.CommentPageGetDTO;
+import com.speakapp.postservice.dtos.ReactionsGetDTO;
+import com.speakapp.postservice.dtos.UserGetDTO;
+import com.speakapp.postservice.entities.Comment;
+import com.speakapp.postservice.entities.CommentReaction;
+import com.speakapp.postservice.entities.Post;
+import com.speakapp.postservice.entities.ReactionType;
+import com.speakapp.postservice.mappers.CommentMapper;
+import com.speakapp.postservice.mappers.CommentPageMapper;
+import com.speakapp.postservice.mappers.ReactionsMapper;
+import com.speakapp.postservice.repositories.CommentReactionRepository;
+import com.speakapp.postservice.repositories.CommentRepository;
+import com.speakapp.postservice.repositories.PostRepository;
+import jakarta.validation.constraints.NotNull;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.*;
+
+@Service
+@RequiredArgsConstructor
+public class CommentService {
+
+    private final PostRepository postRepository;
+    private final CommentRepository commentRepository;
+    private final CommentReactionRepository commentReactionRepository;
+    private final CommentMapper commentMapper;
+    private final CommentPageMapper commentPageMapper;
+    private final UserServiceCommunicationClient userServiceCommunicationClient;
+
+    public CommentPageGetDTO getCommentsForPost(int pageNumber, int pageSize, UUID postId, UUID userId){
+        Optional<Post> postOptional = postRepository.findById(postId);
+        if(postOptional.isEmpty()){
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Post with id = " + postId + " was not found");
+        }
+
+        Post post = postOptional.get();
+        Pageable page = PageRequest.of(pageNumber, pageSize);
+        Page<Comment> commentsPage = commentRepository.findAllByPostOrderByCreatedAtDesc(post, page);
+
+        return createCommentPageGetDTOFromCommentPage(commentsPage, userId, page);
+    }
+
+    // Keep the class implementation for migration to CommentService
+    @NotNull
+    private List<CommentGetDTO> getAllCommentsForThePost(Post post, UUID userId) {
+        List<Comment> comments = commentRepository.findAllByPostOrderByCreatedAtDesc(post);
+
+        List<CommentGetDTO> commentGetDTOS = new ArrayList<>();
+        for (Comment comment : comments) {
+            // TODO: Performance bottleneck in future - consider getting users from user-service by batches
+            UserGetDTO commentAuthor = userServiceCommunicationClient.getUserById(comment.getUserId());
+            ReactionsGetDTO reactionsGetDTO = getReactionsForTheComment(comment);
+            ReactionType currentUserReactionType = commentReactionRepository.findTypeByCommentAndUserId(comment, userId).orElse(null);
+
+            CommentGetDTO commentGetDTO = commentMapper.toGetDTO(
+                    comment,
+                    commentAuthor,
+                    reactionsGetDTO,
+                    currentUserReactionType
+            );
+
+            commentGetDTOS.add(commentGetDTO);
+        }
+
+        return commentGetDTOS;
+    }
+
+    // Keep the class implementation for migration to CommentService
+    // TODO: Possible refactoring - create abstract class with ReactionType field which CommentReaction and PostReaction will extend
+    // then generalize "getReactionsForTheComment" and "getReactionsForThePost" methods into one function
+    private ReactionsGetDTO getReactionsForTheComment(Comment comment) {
+        List<CommentReaction> commentReactions = commentReactionRepository.getCommentReactionByComment(comment);
+
+        Map<ReactionType, Long> sumOfReactionsByType = new EnumMap<>(ReactionType.class);
+        for (CommentReaction commentReaction : commentReactions) {
+            sumOfReactionsByType.merge(commentReaction.getType(), 1L, Long::sum);
+        }
+
+        return ReactionsGetDTO.builder()
+                .sumOfReactionsByType(sumOfReactionsByType)
+                .sumOfReactions(sumOfReactionsByType
+                        .values()
+                        .stream()
+                        .reduce(0L, Long::sum)
+                )
+                .build();
+    }
+
+    private CommentPageGetDTO createCommentPageGetDTOFromCommentPage(Page<Comment> commentsPage, UUID userId, Pageable page){
+        List<CommentGetDTO> commentGetDTOS = commentsPage.getContent().stream().map(comment -> {
+            UserGetDTO commentAuthor = userServiceCommunicationClient.getUserById(comment.getUserId());
+            ReactionsGetDTO commentReactions = getReactionsForTheComment(comment);
+            ReactionType currentUserReactionType = commentReactionRepository.findTypeByCommentAndUserId(comment, userId).orElse(null);
+
+            return commentMapper.toGetDTO(
+                    comment,
+                    commentAuthor,
+                    commentReactions,
+                    currentUserReactionType
+            );
+        }).toList();
+
+        return commentPageMapper.toGetDTO(
+                commentGetDTOS,
+                page,
+                commentsPage.getTotalPages(),
+                commentsPage.getTotalElements()
+        );
+    }
+}

--- a/backend/post-service/src/main/java/com/speakapp/postservice/services/CommentService.java
+++ b/backend/post-service/src/main/java/com/speakapp/postservice/services/CommentService.java
@@ -11,7 +11,6 @@ import com.speakapp.postservice.entities.Post;
 import com.speakapp.postservice.entities.ReactionType;
 import com.speakapp.postservice.mappers.CommentMapper;
 import com.speakapp.postservice.mappers.CommentPageMapper;
-import com.speakapp.postservice.mappers.ReactionsMapper;
 import com.speakapp.postservice.repositories.CommentReactionRepository;
 import com.speakapp.postservice.repositories.CommentRepository;
 import com.speakapp.postservice.repositories.PostRepository;

--- a/backend/post-service/src/main/java/com/speakapp/postservice/services/PostService.java
+++ b/backend/post-service/src/main/java/com/speakapp/postservice/services/PostService.java
@@ -8,7 +8,6 @@ import com.speakapp.postservice.repositories.CommentReactionRepository;
 import com.speakapp.postservice.repositories.CommentRepository;
 import com.speakapp.postservice.repositories.PostReactionRepository;
 import com.speakapp.postservice.repositories.PostRepository;
-import jakarta.validation.constraints.NotNull;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -25,17 +24,9 @@ public class PostService {
 
     private final PostRepository postRepository;
 
-    private final CommentRepository commentRepository;
-
     private final PostReactionRepository postReactionRepository;
 
-    private final CommentReactionRepository commentReactionRepository;
-
     private final PostMapper postMapper;
-
-    private final CommentMapper commentMapper;
-
-    private final CommentPageMapper commentPageMapper;
 
     private final ReactionsMapper reactionsMapper;
 
@@ -113,19 +104,6 @@ public class PostService {
         return createPostPageGetDTOFromPostPage(postsPage, userId, page);
     }
 
-    public CommentPageGetDTO getCommentsForPost(int pageNumber, int pageSize, UUID postId, UUID userId){
-        Optional<Post> postOptional = postRepository.findById(postId);
-        if(postOptional.isEmpty()){
-            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Post with id = " + postId + " was not found");
-        }
-
-        Post post = postOptional.get();
-        Pageable page = PageRequest.of(pageNumber, pageSize);
-        Page<Comment> commentsPage = commentRepository.findAllByPostOrderByCreatedAtDesc(post, page);
-
-        return createCommentPageGetDTOFromCommentPage(commentsPage, userId, page);
-    }
-
     public void deletePost(UUID userId, UUID postId){
 
         Post postToDelete = postRepository.findById(postId).orElseThrow(()->
@@ -136,52 +114,6 @@ public class PostService {
             throw new ResponseStatusException(HttpStatus.FORBIDDEN, "Only author of the post can delete it");
 
         postRepository.delete(postToDelete);
-    }
-
-    // Keep the class implementation for migration to CommentService
-@NotNull
-    private List<CommentGetDTO> getAllCommentsForThePost(Post post, UUID userId) {
-        List<Comment> comments = commentRepository.findAllByPostOrderByCreatedAtDesc(post);
-
-        List<CommentGetDTO> commentGetDTOS = new ArrayList<>();
-        for (Comment comment : comments) {
-            // TODO: Performance bottleneck in future - consider getting users from user-service by batches
-            UserGetDTO commentAuthor = userServiceCommunicationClient.getUserById(comment.getUserId());
-            ReactionsGetDTO reactionsGetDTO = getReactionsForTheComment(comment);
-            ReactionType currentUserReactionType = commentReactionRepository.findTypeByCommentAndUserId(comment, userId).orElse(null);
-
-            CommentGetDTO commentGetDTO = commentMapper.toGetDTO(
-                    comment,
-                    commentAuthor,
-                    reactionsGetDTO,
-                    currentUserReactionType
-            );
-
-            commentGetDTOS.add(commentGetDTO);
-        }
-
-        return commentGetDTOS;
-    }
-
-    // Keep the class implementation for migration to CommentService
-    // TODO: Possible refactoring - create abstract class with ReactionType field which CommentReaction and PostReaction will extend
-    // then generalize "getReactionsForTheComment" and "getReactionsForThePost" methods into one function
-    private ReactionsGetDTO getReactionsForTheComment(Comment comment) {
-        List<CommentReaction> commentReactions = commentReactionRepository.getCommentReactionByComment(comment);
-
-        Map<ReactionType, Long> sumOfReactionsByType = new EnumMap<>(ReactionType.class);
-        for (CommentReaction commentReaction : commentReactions) {
-            sumOfReactionsByType.merge(commentReaction.getType(), 1L, Long::sum);
-        }
-
-        return ReactionsGetDTO.builder()
-                .sumOfReactionsByType(sumOfReactionsByType)
-                .sumOfReactions(sumOfReactionsByType
-                        .values()
-                        .stream()
-                        .reduce(0L, Long::sum)
-                )
-                .build();
     }
 
     // TODO: Possible refactoring - create abstract class with ReactionType field which CommentReaction and PostReaction will extend
@@ -224,26 +156,5 @@ public class PostService {
             postsPage.getTotalPages()
         );
     }
-
-private CommentPageGetDTO createCommentPageGetDTOFromCommentPage(Page<Comment> commentsPage, UUID userId, Pageable page){
-    List<CommentGetDTO> commentGetDTOS = commentsPage.getContent().stream().map(comment -> {
-        UserGetDTO commentAuthor = userServiceCommunicationClient.getUserById(comment.getUserId());
-        ReactionsGetDTO commentReactions = getReactionsForTheComment(comment);
-        ReactionType currentUserReactionType = commentReactionRepository.findTypeByCommentAndUserId(comment, userId).orElse(null);
-
-        return commentMapper.toGetDTO(
-                comment,
-                commentAuthor,
-                commentReactions,
-                currentUserReactionType
-        );
-    }).toList();
-
-    return commentPageMapper.toGetDTO(
-            commentGetDTOS,
-            page,
-            commentsPage.getTotalPages()
-    );
-}
 
 }

--- a/backend/post-service/src/main/java/com/speakapp/postservice/services/PostService.java
+++ b/backend/post-service/src/main/java/com/speakapp/postservice/services/PostService.java
@@ -4,8 +4,6 @@ import com.speakapp.postservice.communication.UserServiceCommunicationClient;
 import com.speakapp.postservice.dtos.*;
 import com.speakapp.postservice.entities.*;
 import com.speakapp.postservice.mappers.*;
-import com.speakapp.postservice.repositories.CommentReactionRepository;
-import com.speakapp.postservice.repositories.CommentRepository;
 import com.speakapp.postservice.repositories.PostReactionRepository;
 import com.speakapp.postservice.repositories.PostRepository;
 import lombok.RequiredArgsConstructor;

--- a/backend/post-service/src/main/resources/data-postgres.sql
+++ b/backend/post-service/src/main/resources/data-postgres.sql
@@ -210,7 +210,7 @@ $$
         -- Reakcje dla post_id_4
         ('6c84fc06-12c4-11ec-82a8-0242ac130003'::uuid, post_id_4, user_id_1, 'LIKE'),
         ('6c84fc12-12c4-11ec-82a8-0242ac130003'::uuid, post_id_4, user_id_2, 'WOW'),
-        ('6c85fc12-12c4-11ec-82a8-0242ac130003'::uuid, post_id_4, user_id_2, 'SAD'),
+        ('6c85fc12-12c4-11ec-82a8-0242ac130003'::uuid, post_id_4, user_id_3, 'SAD'),
 
         -- Reakcje dla post_id_5
         ('6c84fc07-12c4-11ec-82a8-0242ac130003'::uuid, post_id_5, user_id_3, 'SAD'),

--- a/backend/post-service/src/main/resources/requests/PostController/comment-GET.http
+++ b/backend/post-service/src/main/resources/requests/PostController/comment-GET.http
@@ -1,15 +1,15 @@
 ### GET request where current user reacted to a comment in a post
-GET http://localhost:8080/api/posts/comments/?postId=6c84fbae-12c4-11ec-82a8-0242ac130003
+GET http://localhost:8080/api/comments?postId=6c84fbae-12c4-11ec-82a8-0242ac130003
 UserId: 6c84fb9b-12c4-11ec-82a8-0242ac130003
 
 ### GET request with getting page different than 0
-GET http://localhost:8080/api/posts/comments/?postId=6c84fbad-12c4-11ec-82a8-0242ac130003&pageNumber=1
+GET http://localhost:8080/api/comments?postId=6c84fbad-12c4-11ec-82a8-0242ac130003&pageNumber=1
 UserId: 6c84fb9b-12c4-11ec-82a8-0242ac130003
 
 ### GET request with setting pageSize
-GET http://localhost:8080/api/posts/comments/?postId=6c84fbad-12c4-11ec-82a8-0242ac130003&pageSize=4
+GET http://localhost:8080/api/comments?postId=6c84fbad-12c4-11ec-82a8-0242ac130003&pageSize=4
 UserId: 6c84fb9b-12c4-11ec-82a8-0242ac130003
 
 ### GET request with postId that doesnt exist (ERROR 400)
-GET http://localhost:8080/api/posts/comments/?postId=6c84fbad-12c9-11ec-82a8-0242ac130003&pageSize=4
+GET http://localhost:8080/api/comments?postId=6c84fbad-12c9-11ec-82a8-0242ac130003&pageSize=4
 UserId: 6c84fb9b-12c4-11ec-82a8-0242ac130003


### PR DESCRIPTION
Zmiany:
 - przeniosłem metody związane z komentarzami do osobnego kontrolera i serwisu
 - zmieniłem enpoint komentarzy z api/posts/comments/ na api/comments (zeby było zgodnie z innymi serwisami)
 - dodałem createdAt modifiedAt i totalComments do zwracanych wartości
 - poprawiłem błąd w data-postgres.sql