### PR TITLE
Spa 280 keycloak serwis mailowy

### DIFF
--- a/backend/compose.yml
+++ b/backend/compose.yml
@@ -179,6 +179,7 @@ services:
       - KC_DB_USERNAME=postgres
       - KC_DB_PASSWORD=postgres
       - KC_DB_URL_PORT=5434
+      - JAVA_OPTS_APPEND=-Dkeycloak.profile.feature.upload_scripts=enabled -Dkeycloak.migration.strategy=OVERWRITE_EXISTING
     volumes:
       - ./keycloak-service/themes:/opt/keycloak/themes
       - ./keycloak-service/realm-export.json:/opt/keycloak/data/import/realm-export.json

--- a/backend/compose.yml
+++ b/backend/compose.yml
@@ -179,7 +179,6 @@ services:
       - KC_DB_USERNAME=postgres
       - KC_DB_PASSWORD=postgres
       - KC_DB_URL_PORT=5434
-      - JAVA_OPTS_APPEND=-Dkeycloak.profile.feature.upload_scripts=enabled -Dkeycloak.migration.strategy=OVERWRITE_EXISTING
     volumes:
       - ./keycloak-service/themes:/opt/keycloak/themes
       - ./keycloak-service/realm-export.json:/opt/keycloak/data/import/realm-export.json

--- a/backend/keycloak-service/realm-export.json
+++ b/backend/keycloak-service/realm-export.json
@@ -1714,7 +1714,7 @@
     "auth": "true",
     "envelopeFrom": "",
     "ssl": "true",
-    "password": "**********",
+    "password": "gutg vlke lrlr vkuf",
     "port": "465",
     "host": "smtp.gmail.com",
     "replyTo": "speakappproject@gmail.com",

--- a/backend/keycloak-service/realm-export.json
+++ b/backend/keycloak-service/realm-export.json
@@ -1708,7 +1708,20 @@
     "xXSSProtection": "1; mode=block",
     "strictTransportSecurity": "max-age=31536000; includeSubDomains"
   },
-  "smtpServer": {},
+  "smtpServer": {
+    "replyToDisplayName": "SpeakApp",
+    "starttls": "false",
+    "auth": "true",
+    "envelopeFrom": "",
+    "ssl": "true",
+    "password": "**********",
+    "port": "465",
+    "host": "smtp.gmail.com",
+    "replyTo": "speakappproject@gmail.com",
+    "from": "speakappproject@gmail.com",
+    "fromDisplayName": "SpeakApp",
+    "user": "speakappproject@gmail.com"
+  },
   "eventsEnabled": false,
   "eventsListeners": [
     "custom-event-listener",


### PR DESCRIPTION
Ustawienie konta mailowego w Keycloaku. Teraz jak ktoś zapomni hasła i wybierze opcję forgot password to rzeczywiście mail zostanie wysłany (jeżeli jakikolwiek użytkownik taki mail posiada i ten mail istnieje).

Sprawdzałem patrząc czy utworzone konto dla aplikacji wysyła maile do innych i hasło sprawdzałem klikając link w wiadomościach wysyłanych - wszystko wydaje się działać.

Poza tym dodałem opcję nadpisywania realm'u przy uruchamianiu keycloaka - bez tego jeżeli macie już ustawionego keycloaka na urządzeniu żadne zmiany by się nie wprowadziły (ale też przez to będzie się dłużej stawiał).