### PR TITLE
fix updating auditable on number of reactions chage

### DIFF
--- a/backend/post-service/src/main/java/com/speakapp/postservice/entities/Comment.java
+++ b/backend/post-service/src/main/java/com/speakapp/postservice/entities/Comment.java
@@ -37,19 +37,4 @@ public class Comment extends Auditable {
     private String content;
 
     private int numberOfReactions;
-
-    public void incrementNumberOfReactions() {
-        numberOfReactions++;
-    }
-
-    public void decrementNumberOfReactions() {
-        if(numberOfReactions > 0) {
-            numberOfReactions--;
-        }
-    }
-
-    //   TODO Media service for photos, audio, video
-    //    @Lob
-    //    private byte[] media;
-
 }

--- a/backend/post-service/src/main/java/com/speakapp/postservice/repositories/CommentRepository.java
+++ b/backend/post-service/src/main/java/com/speakapp/postservice/repositories/CommentRepository.java
@@ -7,8 +7,12 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.EnableTransactionManagement;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.UUID;
@@ -18,10 +22,15 @@ import java.util.UUID;
 @Configuration
 @EntityScan("com.speakapp.postservice.entities")
 public interface CommentRepository extends JpaRepository<Comment, UUID> {
-    Page<Comment> findAllByPost(Post post, Pageable pageable);
-
-    List<Comment> findAllByPostOrderByCreatedAtDesc(Post post);
-
-
     Long countAllByPost(Post post);
+
+    @Transactional
+    @Modifying
+    @Query("update Comment c set c.numberOfReactions = c.numberOfReactions + 1 where c.commentId = :id")
+    void incrementNumberOfReactions(@Param("id") UUID id);
+
+    @Transactional
+    @Modifying
+    @Query("update Comment c set c.numberOfReactions = c.numberOfReactions - 1 where c.commentId = :id and c.numberOfReactions > 0")
+    void decrementNumberOfReactions(@Param("id") UUID id);
 }

--- a/backend/post-service/src/main/java/com/speakapp/postservice/services/ReactionService.java
+++ b/backend/post-service/src/main/java/com/speakapp/postservice/services/ReactionService.java
@@ -47,7 +47,7 @@ public class ReactionService {
         CommentReaction oldReaction = commentReactionRepository.findCommentReactionByCommentAndUserId(comment, userId);
 
         if (oldReaction == null && newReaction != null) {
-            comment.incrementNumberOfReactions();
+            commentRepository.incrementNumberOfReactions(commentId);
             commentReactionRepository.save(CommentReaction.builder()
                     .comment(comment)
                     .userId(userId)
@@ -55,7 +55,7 @@ public class ReactionService {
                     .build());
         }
         if (oldReaction != null && newReaction == null) {
-            comment.decrementNumberOfReactions();
+            commentRepository.decrementNumberOfReactions(commentId);
             commentReactionRepository.delete(oldReaction);
         }
         if (oldReaction != null && newReaction != null) {


### PR DESCRIPTION
Znalazłem buga: przy edycji (putsert) reakcji komentarzy zmieniała się wartość numberOfReactions co powodowało zmianę daty modifiedAt w Auditable.

Stworzyłem dwie nowe metody do zmiany wartości numberOfReactions. O ile dobrze rozumiem pisanie query bezpośrednio omija listener w klasie Auditable - dzięki czemu modifiedAt nie jest aktualizowany (i nie pojawia się informacja o edycji komentarza przy dodaniu reakcji XD).