### PR TITLE
fixed class variables

### DIFF
--- a/backend/user-service/src/main/java/com/speakapp/userservice/dtos/AppUserWithFriendStatusGetDTO.java
+++ b/backend/user-service/src/main/java/com/speakapp/userservice/dtos/AppUserWithFriendStatusGetDTO.java
@@ -15,8 +15,8 @@ public class AppUserWithFriendStatusGetDTO {
     UUID userId;
     String firstName;
     String lastName;
-    String profilePhotoUrl;
-    String bgPhotoUrl;
+    UUID profilePhotoId;
+    UUID bgPhotoId;
     String email;
     String about;
     String friendStatus;


### PR DESCRIPTION
Mały błąd w klasie, zamiast String photoUrl powinno być UUID photoId - z tego powodu przy ładowaniu profilu użytkownika nie było widać zdjęć nawet jeżeli takowe istniały (mapper nie ustawiał wartości).