### PR TITLE
SPA-285 Add limited websocket session lifetime

### DIFF
--- a/backend/chat-service/src/main/java/com/chatservice/config/WebSocketConfig.java
+++ b/backend/chat-service/src/main/java/com/chatservice/config/WebSocketConfig.java
@@ -1,10 +1,12 @@
 package com.chatservice.config;
 
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.messaging.simp.config.MessageBrokerRegistry;
 import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
 import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
 import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
+import org.springframework.web.socket.server.standard.ServletServerContainerFactoryBean;
 
 @Configuration
 @EnableWebSocketMessageBroker
@@ -21,5 +23,11 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
         registry.addEndpoint("/ws").withSockJS();
     }
 
+    @Bean
+    public ServletServerContainerFactoryBean createWebSocketContainer() {
+        ServletServerContainerFactoryBean container = new ServletServerContainerFactoryBean();
+        container.setMaxSessionIdleTimeout(5*60*1000L); // 15 s
+        return container;
+    }
 
 }

--- a/backend/chat-service/src/main/java/com/chatservice/config/WebSocketConfig.java
+++ b/backend/chat-service/src/main/java/com/chatservice/config/WebSocketConfig.java
@@ -26,7 +26,7 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
     @Bean
     public ServletServerContainerFactoryBean createWebSocketContainer() {
         ServletServerContainerFactoryBean container = new ServletServerContainerFactoryBean();
-        container.setMaxSessionIdleTimeout(5*60*1000L); // 15 s
+        container.setMaxSessionIdleTimeout(5*60*1000L); // 15 min
         return container;
     }
 

--- a/backend/chat-service/src/main/resources/static/js/main.js
+++ b/backend/chat-service/src/main/resources/static/js/main.js
@@ -28,6 +28,7 @@ function connect(event) {
 
         stompClient.connect({}, onConnected, onError);
     }
+
     event.preventDefault();
 }
 
@@ -41,6 +42,11 @@ function onConnected() {
         {},
         JSON.stringify({sender: username, type: 'JOIN'})
     )
+
+    stompClient.ws.onclose = function(event) {
+        alert("Session expired - send new handshake request");
+        console.log("Session expired");
+    };
 
     connectingElement.classList.add('hidden');
 }


### PR DESCRIPTION
Dodałem że po 5 minutach sesja weboscket jest usuwana i trzeba ponownie wysłać handshake żadaniem http żeby móc się ponownie podłączyć do chatu i otrzymywać wiadomości.

Przetestowałem na przykładowym frontendzie do chatu w pliku main.js i wykrywało odpowiednio zerwanie połączenia po określonym czasie.